### PR TITLE
Only register .well-known/masque

### DIFF
--- a/draft-ietf-masque-connect-udp.md
+++ b/draft-ietf-masque-connect-udp.md
@@ -576,13 +576,13 @@ Reference:
 
 ## Well-Known URI {#iana-uri}
 
-This document will request IANA to register "masque/udp" in the "Well-Known
+This document will request IANA to register "masque" in the "Well-Known
 URIs" registry maintained at
 <[](https://www.iana.org/assignments/well-known-uris)>.
 
 URI Suffix:
 
-: masque/udp
+: masque
 
 Change Controller:
 
@@ -598,8 +598,7 @@ Status:
 
 Related Information:
 
-: Includes all resources identified with the path prefix
-"/.well-known/masque/udp/"
+: Includes all resources identified with the path prefix "/.well-known/masque/"
 {: spacing="compact"}
 
 

--- a/draft-ietf-masque-connect-udp.md
+++ b/draft-ietf-masque-connect-udp.md
@@ -598,7 +598,8 @@ Status:
 
 Related Information:
 
-: Includes all resources identified with the path prefix "/.well-known/masque/"
+: Includes all resources identified with the path prefix
+"/.well-known/masque/udp/"
 {: spacing="compact"}
 
 


### PR DESCRIPTION
As per [RFC 8615 s3](https://www.rfc-editor.org/rfc/rfc8615.html#section-3) registrations cannot contain a `/` character so we register `.well-known/masque` instead of `.well-known/masque/udp`