### PR TITLE
SECDIR review: Improve Security Considerations

### DIFF
--- a/draft-ietf-masque-connect-udp.md
+++ b/draft-ietf-masque-connect-udp.md
@@ -527,7 +527,7 @@ attributed to the UDP proxy. HTTP servers that support UDP proxying ought to
 restrict its use to authenticated users.
 
 UDP proxies have similar properties to TCP proxies when it comes to facilitating
-denial of service attacks, even though TCP offers better protection in theory.
+denial of service attacks. In theory, the stateful nature of TCP provides better protection that stateless UDP. However, in practice there are negligible differences when considering proxying.
 Because the CONNECT method creates a TCP connection to the target, the target
 has to indicate its willingness to accept TCP connections by responding with a
 TCP SYN-ACK before the CONNECT proxy can send it application data. UDP doesn't

--- a/draft-ietf-masque-connect-udp.md
+++ b/draft-ietf-masque-connect-udp.md
@@ -527,19 +527,20 @@ attributed to the UDP proxy. HTTP servers that support UDP proxying ought to
 restrict its use to authenticated users.
 
 UDP proxies have similar properties to TCP proxies when it comes to facilitating
-denial of service attacks. In theory, the stateful nature of TCP provides better protection that stateless UDP. However, in practice there are negligible differences when considering proxying.
-Because the CONNECT method creates a TCP connection to the target, the target
-has to indicate its willingness to accept TCP connections by responding with a
-TCP SYN-ACK before the CONNECT proxy can send it application data. UDP doesn't
-have this property, so a UDP proxy could send more data to an unwilling target
-than a CONNECT proxy. However, in practice denial of service attacks target open
-TCP ports so the TCP SYN-ACK does not offer much protection in real scenarios.
-While a UDP proxy could potentially limit the number of UDP packets it is
-willing to forward until it has observed a response from the target, that is
-unlikely to provide any protection against denial of service attacks because
-such attacks target open UDP ports where the protocol running over UDP would
-respond, and that would be interpreted as willingness to accept UDP by the UDP
-proxy.
+denial of service attacks. In theory the stateful nature of TCP provides better
+protection than stateless UDP but in practice this provides negligible benefits
+when considering proxying. Because the CONNECT method creates a TCP connection
+to the target, the target has to indicate its willingness to accept TCP
+connections by responding with a TCP SYN-ACK before the CONNECT proxy can send
+it application data. UDP doesn't have this property, so a UDP proxy could send
+more data to an unwilling target than a CONNECT proxy. However, in practice
+denial of service attacks target open TCP ports so the TCP SYN-ACK does not
+offer much protection in real scenarios. While a UDP proxy could potentially
+limit the number of UDP packets it is willing to forward until it has observed a
+response from the target, that is unlikely to provide any protection against
+denial of service attacks because such attacks target open UDP ports where the
+protocol running over UDP would respond, and that would be interpreted as
+willingness to accept UDP by the UDP proxy.
 
 The security considerations described in {{HTTP-DGRAM}} also apply here.
 

--- a/draft-ietf-masque-connect-udp.md
+++ b/draft-ietf-masque-connect-udp.md
@@ -526,6 +526,8 @@ to arbitrary targets, as that could allow bad actors to send traffic and have it
 attributed to the UDP proxy. HTTP servers that support UDP proxying ought to
 restrict its use to authenticated users.
 
+UDP proxies have similar properties to TCP proxies when it comes to facilitating
+denial of service attacks, even though TCP offers better protection in theory.
 Because the CONNECT method creates a TCP connection to the target, the target
 has to indicate its willingness to accept TCP connections by responding with a
 TCP SYN-ACK before the CONNECT proxy can send it application data. UDP doesn't
@@ -538,11 +540,6 @@ unlikely to provide any protection against denial of service attacks because
 such attacks target open UDP ports where the protocol running over UDP would
 respond, and that would be interpreted as willingness to accept UDP by the UDP
 proxy.
-
-UDP sockets for UDP proxying have a different lifetime than TCP sockets for
-CONNECT, therefore implementors would be well served to follow the advice in
-{{handling}} if they base their UDP proxying implementation on a preexisting
-implementation of CONNECT.
 
 The security considerations described in {{HTTP-DGRAM}} also apply here.
 


### PR DESCRIPTION
This PR is in response to [Catherine Meadows' SECDIR review](https://mailarchive.ietf.org/arch/msg/masque/hY6p1ZYMwlHEl618np7N3pnsxgU/).

It improves the clarity of the Security Considerations section:
* the paragraph about willingness to receive needed an introductory sentence
* the paragraph about lifetimes no longer made sense and is removed